### PR TITLE
Django 1.8 support (Work in progress)

### DIFF
--- a/django_jinja/apps.py
+++ b/django_jinja/apps.py
@@ -1,3 +1,5 @@
+import django
+
 from django.apps import AppConfig
 from django_jinja import base
 
@@ -7,5 +9,4 @@ class DjangoJinjaAppConfig(AppConfig):
     verbose_name = "Django Jinja"
 
     def ready(self):
-        base.env.initialize()
-
+        base.setup()

--- a/django_jinja/apps.py
+++ b/django_jinja/apps.py
@@ -10,3 +10,5 @@ class DjangoJinjaAppConfig(AppConfig):
 
     def ready(self):
         base.setup()
+        if django.VERSION[:2] <= (1, 7):
+            base.initialize(base.env)

--- a/django_jinja/apps.py
+++ b/django_jinja/apps.py
@@ -9,6 +9,7 @@ class DjangoJinjaAppConfig(AppConfig):
     verbose_name = "Django Jinja"
 
     def ready(self):
-        base.setup()
         if django.VERSION[:2] <= (1, 7):
-            base.initialize(base.env)
+            base.setup_django_lte_17()
+        else:
+            base.setup_django_gte_18()

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -10,17 +10,21 @@ django_jinja easy with django 1.8.
 from __future__ import absolute_import
 
 import sys
+import copy
 import jinja2
 
 from django.conf import settings
 from django.template import TemplateDoesNotExist, TemplateSyntaxError
 from django.utils import six
+from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
 from django.template.backends.base import BaseEngine
 from django.template.backends.utils import csrf_input_lazy, csrf_token_lazy
 
 from . import base
+from . import utils
+from . import builtins
 
 
 class Jinja2(BaseEngine):
@@ -31,26 +35,89 @@ class Jinja2(BaseEngine):
         options = params.pop("OPTIONS", {}).copy()
         super(Jinja2, self).__init__(params)
 
-        environment_clspath = options.pop("environment", None)
+        newstyle_gettext = options.pop("newstyle_gettext", True)
+        context_processors = options.pop("context_processors", [])
+
+        environment_clspath = options.pop("environment", "jinja2.Environment")
+        environment_cls = import_string(environment_clspath)
+
 
         options.setdefault("loader", jinja2.FileSystemLoader(self.template_dirs))
+        options.setdefault("extensions", base.DEFAULT_EXTENSIONS)
         options.setdefault("auto_reload", settings.DEBUG)
+        options.setdefault("autoescape", True)
 
-        self.env = base.make_environemnt(defaults=options,
-                                         clspath=environment_clspath)
+        if settings.DEBUG:
+            options.setdefault("undefined", jinja2.DebugUndefined)
+        else:
+            options.setdefault("undefined", jinja2.Undefined)
 
-        base._initialize_builtins(self.env)
+        self.env = environment_cls(**options)
+        self._context_processors = context_processors
+
+        self._initialize_i18n(newstyle_gettext)
+        self._initialize_builtins()
+        self._initialize_thirdparty()
+
+    def _initialize_thirdparty(self):
         base._initialize_thirdparty(self.env)
-        base._initialize_i18n(self.env)
-        base._initialize_bytecode_cache(self.env)
 
+    def _initialize_i18n(self, newstyle):
+        # Initialize i18n support
+        if settings.USE_I18N:
+            from django.utils import translation
+            self.env.install_gettext_translations(translation, newstyle=newstyle)
+        else:
+            self.env.install_null_translations(newstyle=newstyle)
+
+    def _initialize_builtins(self, filters=None, tests=None, globals=None, constants=None):
+        _filters = copy.copy(base.JINJA2_FILTERS)
+        if filters is not None:
+            _filters.update(filters)
+
+        _globals = copy.copy(base.JINJA2_GLOBALS)
+        if globals is not None:
+            _globals.update(globals)
+
+        _tests = copy.copy(base.JINJA2_TESTS)
+        if tests is not None:
+            _tests.update(tests)
+
+        _constants = copy.copy(base.JINJA2_CONSTANTS)
+        if constants is not None:
+            _constants.update(constants)
+
+        def insert(data, name, value):
+            if isinstance(value, six.string_types):
+                data[name] = import_string(value)
+            else:
+                data[name] = value
+
+        for name, value in _filters.items():
+            insert(self.env.filters, name, value)
+
+        for name, value in _tests.items():
+            insert(self.env.tests, name, value)
+
+        for name, value in _globals.items():
+            insert(self.env.globals, name, value)
+
+        for name, value in _constants.items():
+            self.env.globals[name] = value
+
+        self.env.add_extension(builtins.extensions.CsrfExtension)
+        self.env.add_extension(builtins.extensions.CacheExtension)
+
+    @cached_property
+    def context_processors(self):
+        return tuple(import_string(path) for path in self._context_processors)
 
     def from_string(self, template_code):
-        return Template(self.env.from_string(template_code))
+        return Template(self.env.from_string(template_code), self)
 
     def get_template(self, template_name):
         try:
-            return Template(self.env.get_template(template_name))
+            return Template(self.env.get_template(template_name), self)
         except jinja2.TemplateNotFound as exc:
             six.reraise(TemplateDoesNotExist, TemplateDoesNotExist(exc.args),
                         sys.exc_info()[2])
@@ -61,14 +128,22 @@ class Jinja2(BaseEngine):
 from django.template import RequestContext
 
 class Template(object):
-    def __init__(self, template):
+    def __init__(self, template, backend):
         self.template = template
+        self.backend = backend
+
 
     def render(self, context=None, request=None):
         if context is None:
             context = {}
+
         if request is not None:
             context["request"] = request
             context["csrf_input"] = csrf_input_lazy(request)
             context["csrf_token"] = csrf_token_lazy(request)
+
+            # Support for django context processors
+            for processor in self.backend.context_processors:
+                context.update(processor(request))
+
         return self.template.render(context)

--- a/django_jinja/backend.py
+++ b/django_jinja/backend.py
@@ -1,0 +1,74 @@
+"""
+Since django 1.8.x, django comes with native multiple template engine support.
+It also comes with jinja2 backend, but it is slightly unflexible, and it does
+not support by default all django filters and related stuff.
+
+This is an implementation of django backend inteface for use
+django_jinja easy with django 1.8.
+"""
+
+from __future__ import absolute_import
+
+import sys
+import jinja2
+
+from django.conf import settings
+from django.template import TemplateDoesNotExist, TemplateSyntaxError
+from django.utils import six
+from django.utils.module_loading import import_string
+
+from django.template.backends.base import BaseEngine
+from django.template.backends.utils import csrf_input_lazy, csrf_token_lazy
+
+from . import base
+
+
+class Jinja2(BaseEngine):
+    app_dirname = "templates"
+
+    def __init__(self, params):
+        params = params.copy()
+        options = params.pop("OPTIONS", {}).copy()
+        super(Jinja2, self).__init__(params)
+
+        environment_clspath = options.pop("environment", None)
+
+        options.setdefault("loader", jinja2.FileSystemLoader(self.template_dirs))
+        options.setdefault("auto_reload", settings.DEBUG)
+
+        self.env = base.make_environemnt(defaults=options,
+                                         clspath=environment_clspath)
+
+        base._initialize_builtins(self.env)
+        base._initialize_thirdparty(self.env)
+        base._initialize_i18n(self.env)
+        base._initialize_bytecode_cache(self.env)
+
+
+    def from_string(self, template_code):
+        return Template(self.env.from_string(template_code))
+
+    def get_template(self, template_name):
+        try:
+            return Template(self.env.get_template(template_name))
+        except jinja2.TemplateNotFound as exc:
+            six.reraise(TemplateDoesNotExist, TemplateDoesNotExist(exc.args),
+                        sys.exc_info()[2])
+        except jinja2.TemplateSyntaxError as exc:
+            six.reraise(TemplateSyntaxError, TemplateSyntaxError(exc.args),
+                        sys.exc_info()[2])
+
+from django.template import RequestContext
+
+class Template(object):
+    def __init__(self, template):
+        self.template = template
+
+    def render(self, context=None, request=None):
+        if context is None:
+            context = {}
+        if request is not None:
+            context["request"] = request
+            context["csrf_input"] = csrf_input_lazy(request)
+            context["csrf_token"] = csrf_token_lazy(request)
+        return self.template.render(context)

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -354,4 +354,5 @@ env = make_environemnt()
 
 # Fallback for prevous django versions.
 if django.VERSION[:2] < (1, 7):
+    initialize(env)
     setup()

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -341,17 +341,22 @@ def initialize(environment):
     _initialize_template_loader(environment)
 
 
-def setup():
+env = None
+
+def setup_django_lte_17():
+    global env
+    env = make_environemnt()
+
+    patch_django_for_autoescape()
+    preload_templatetags_from_apps()
+    initialize(env)
+
+
+def setup_django_gte_18():
     patch_django_for_autoescape()
     preload_templatetags_from_apps()
 
 
-# Create a global instance for preserve
-# the previos behavior (django <= 1.7.x)
-env = make_environemnt()
-
-
 # Fallback for prevous django versions.
 if django.VERSION[:2] < (1, 7):
-    initialize(env)
     setup()

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -298,6 +298,15 @@ def _initialize_bytecode_cache(env):
         env.bytecode_cache = cls(JINJA2_BYTECODE_CACHE_NAME)
 
 
+def match_template(template_name, regex=None, extension=None):
+    if extension is not None:
+        return template_name.endswith(extension)
+    elif regex:
+        return regex.match(template_name)
+    else:
+        return False
+
+
 def make_environemnt(defaults=None, clspath=None):
     """
     Create a new instance of jinja2 environment.
@@ -327,6 +336,7 @@ def make_environemnt(defaults=None, clspath=None):
     env.template_class = Template
 
     return env
+
 
 
 def initialize(environment):

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -329,22 +329,21 @@ def make_environemnt(defaults=None, clspath=None):
     return env
 
 
-def initialize(env):
+def initialize(environment):
     """
     Initialize given environment populating it with
     builtins and with django i18n data.
     """
-    _initialize_builtins(env)
-    _initialize_thirdparty(env)
-    _initialize_i18n(env)
-    _initialize_template_loader(env)
-    _initialize_bytecode_cache(env)
+    _initialize_builtins(environment)
+    _initialize_thirdparty(environment)
+    _initialize_i18n(environment)
+    _initialize_bytecode_cache(environment)
+    _initialize_template_loader(environment)
 
 
 def setup():
     patch_django_for_autoescape()
     preload_templatetags_from_apps()
-    initialize(env)
 
 
 # Create a global instance for preserve

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -6,7 +6,7 @@ import django
 import jinja2
 
 from django.conf import settings
-from django.template import Origin
+# from django.template import Origin
 from django.template.context import BaseContext
 from django.utils.importlib import import_module
 from django.utils import six
@@ -45,7 +45,7 @@ JINJA2_FILTERS = {
     "addslashes": "django_jinja.builtins.filters.addslashes",
     "capfirst": "django_jinja.builtins.filters.capfirst",
     "escapejs": "django_jinja.builtins.filters.escapejs_filter",
-    "fix_ampersands": "django_jinja.builtins.filters.fix_ampersands_filter",
+    # "fix_ampersands": "django_jinja.builtins.filters.fix_ampersands_filter",
     "floatformat": "django_jinja.builtins.filters.floatformat",
     "iriencode": "django_jinja.builtins.filters.iriencode",
     "linenumbers": "django_jinja.builtins.filters.linenumbers",
@@ -132,7 +132,7 @@ class Template(jinja2.Template):
         new_context = dict_from_context(context)
         if settings.TEMPLATE_DEBUG:
             from django.test import signals
-            self.origin = Origin(self.filename)
+            # self.origin = Origin(self.filename)
             signals.template_rendered.send(sender=self, template=self, context=context)
 
         return super(Template, self).render(new_context)
@@ -141,7 +141,7 @@ class Template(jinja2.Template):
         new_context = dict_from_context(context)
         if settings.TEMPLATE_DEBUG:
             from django.test import signals
-            self.origin = Origin(self.filename)
+            # self.origin = Origin(self.filename)
             signals.template_rendered.send(sender=self, template=self, context=context)
 
         return super(Template, self).stream(new_context)

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -3,10 +3,7 @@
 import os
 
 import django
-
-from jinja2 import Environment
-from jinja2 import Template
-from jinja2 import FileSystemLoader
+import jinja2
 
 from django.conf import settings
 from django.template import Origin
@@ -18,6 +15,14 @@ from . import builtins
 from . import library
 from . import utils
 
+# Default jinja extension list
+DEFAULT_EXTENSIONS = [
+    "jinja2.ext.do",
+    "jinja2.ext.loopcontrols",
+    "jinja2.ext.with_",
+    "jinja2.ext.i18n",
+    "jinja2.ext.autoescape",
+]
 
 JINJA2_ENVIRONMENT_OPTIONS = getattr(settings, "JINJA2_ENVIRONMENT_OPTIONS", {})
 JINJA2_EXTENSIONS = getattr(settings, "JINJA2_EXTENSIONS", [])
@@ -32,16 +37,6 @@ JINJA2_BYTECODE_CACHE_BACKEND = getattr(settings, "JINJA2_BYTECODE_CACHE_BACKEND
 
 JINJA2_CONSTANTS = getattr(settings, "JINJA2_CONSTANTS", {})
 JINJA2_TESTS = getattr(settings, "JINJA2_TESTS", {})
-
-
-# Default jinja extension list
-DEFAULT_EXTENSIONS = [
-    "jinja2.ext.do",
-    "jinja2.ext.loopcontrols",
-    "jinja2.ext.with_",
-    "jinja2.ext.i18n",
-    "jinja2.ext.autoescape",
-]
 
 
 JINJA2_FILTERS = {
@@ -127,15 +122,14 @@ def dict_from_context(context):
     return dict(context)
 
 
-class Template(Template):
+class Template(jinja2.Template):
     """
-    Customized template class.
+    Customized jinja2 Template subclass.
     Add correct handling django context objects.
     """
 
     def render(self, context={}):
         new_context = dict_from_context(context)
-
         if settings.TEMPLATE_DEBUG:
             from django.test import signals
             self.origin = Origin(self.filename)
@@ -145,7 +139,6 @@ class Template(Template):
 
     def stream(self, context={}):
         new_context = dict_from_context(context)
-
         if settings.TEMPLATE_DEBUG:
             from django.test import signals
             self.origin = Origin(self.filename)
@@ -154,171 +147,211 @@ class Template(Template):
         return super(Template, self).stream(new_context)
 
 
-class Environment(Environment):
-    def initialize(self):
-        self.initialize_i18n()
-        self.initialize_bytecode_cache()
-        self.initialize_template_loader()
-        self.initialize_autoescape()
-        self.initialize_builtins()
-        self.initialize_thirdparty_templatetags()
+def _iter_templatetags_modules_list():
+    """
+    Get list of modules that contains templatetags
+    submodule.
+    """
+    # Django 1.7 compatibility imports
+    try:
+        from django.apps import apps
+        all_modules = [x.name for x in apps.get_app_configs()]
+    except ImportError:
+        all_modules = settings.INSTALLED_APPS
 
-    def initialize_i18n(self):
-        # install translations
-        if settings.USE_I18N:
-            from django.utils import translation
-            self.install_gettext_translations(translation, newstyle=JINJA2_NEWSTYLE_GETTEXT)
-        else:
-            self.install_null_translations(newstyle=JINJA2_NEWSTYLE_GETTEXT)
-
-    def initialize_bytecode_cache(self):
-        # Install bytecode cache if is enabled
-        if JINJA2_BYTECODE_CACHE_ENABLE:
-            cls = utils.load_class(JINJA2_BYTECODE_CACHE_BACKEND)
-            self.bytecode_cache = cls(JINJA2_BYTECODE_CACHE_NAME)
-
-    def initialize_template_loader(self):
-        self.template_class = Template
-
-        loader = getattr(settings, "JINJA2_LOADER", None)
-        if loader is None:
-            from django.template.loaders import app_directories
-            default_loader_dirs = (tuple(settings.TEMPLATE_DIRS) +
-                                   app_directories.app_template_dirs)
-
-            self.loader = FileSystemLoader(default_loader_dirs)
-        elif isinstance(loader, six.string_types):
-            loader_params = getattr(settings, "JINJA2_LOADER_SETTINGS", {})
-            cls = utils.load_class(loader)
-            self.loader = cls(**loader_params)
-        else:
-            self.loader = loader
-
-    def initialize_autoescape(self):
-        if not self.autoescape:
-            return
-
-        from django.utils import safestring
-        from django.forms.forms import BoundField
-
+    for app_path in all_modules:
         try:
-            from django.forms.utils import ErrorList
-            from django.forms.utils import ErrorDict
-
-        # Just for django < 1.7 compatibility
+            mod = import_module(app_path + ".templatetags")
+            if mod is not None:
+                yield (app_path, os.path.dirname(mod.__file__))
         except ImportError:
-            from django.forms.util import ErrorList
-            from django.forms.util import ErrorDict
+            pass
 
-        if hasattr(safestring, "SafeText"):
-            if not hasattr(safestring.SafeText, "__html__"):
-                safestring.SafeText.__html__ = lambda self: six.text_type(self)
 
-        if hasattr(safestring, "SafeString"):
-            if not hasattr(safestring.SafeString, "__html__"):
-                safestring.SafeString.__html__ = lambda self: six.text_type(self)
+def patch_django_for_autoescape():
+    """
+    Patch django modules for make them compatible with
+    jinja autoescape implementation.
+    """
+    from django.utils import safestring
+    from django.forms.forms import BoundField
 
-        if hasattr(safestring, "SafeUnicode"):
-            if not hasattr(safestring.SafeUnicode, "__html__"):
-                safestring.SafeUnicode.__html__ = lambda self: six.text_type(self)
+    try:
+        from django.forms.utils import ErrorList
+        from django.forms.utils import ErrorDict
 
-        if hasattr(safestring, "SafeBytes"):
-            if not hasattr(safestring.SafeBytes, "__html__"):
-                safestring.SafeBytes.__html__ = lambda self: six.text_type(self)
+    # Just for django < 1.7 compatibility
+    except ImportError:
+        from django.forms.util import ErrorList
+        from django.forms.util import ErrorDict
 
-        if not hasattr(BoundField, "__html__"):
-            BoundField.__html__ = lambda self: six.text_type(self)
+    if hasattr(safestring, "SafeText"):
+        if not hasattr(safestring.SafeText, "__html__"):
+            safestring.SafeText.__html__ = lambda self: six.text_type(self)
 
-        if not hasattr(ErrorList, "__html__"):
-            ErrorList.__html__ = lambda self: six.text_type(self)
+    if hasattr(safestring, "SafeString"):
+        if not hasattr(safestring.SafeString, "__html__"):
+            safestring.SafeString.__html__ = lambda self: six.text_type(self)
 
-        if not hasattr(ErrorDict, "__html__"):
-            ErrorDict.__html__ = lambda self: six.text_type(self)
+    if hasattr(safestring, "SafeUnicode"):
+        if not hasattr(safestring.SafeUnicode, "__html__"):
+            safestring.SafeUnicode.__html__ = lambda self: six.text_type(self)
 
-    def initialize_builtins(self):
-        for name, value in JINJA2_FILTERS.items():
-            if isinstance(value, six.string_types):
-                self.filters[name] = utils.load_class(value)
-            else:
-                self.filters[name] = value
+    if hasattr(safestring, "SafeBytes"):
+        if not hasattr(safestring.SafeBytes, "__html__"):
+            safestring.SafeBytes.__html__ = lambda self: six.text_type(self)
 
-        for name, value in JINJA2_TESTS.items():
-            if isinstance(value, six.string_types):
-                self.tests[name] = utils.load_class(value)
-            else:
-                self.tests[name] = value
+    if not hasattr(BoundField, "__html__"):
+        BoundField.__html__ = lambda self: six.text_type(self)
 
-        for name, value in JINJA2_GLOBALS.items():
-            if isinstance(value, six.string_types):
-                self.globals[name] = utils.load_class(value)
-            else:
-                self.globals[name] = value
+    if not hasattr(ErrorList, "__html__"):
+        ErrorList.__html__ = lambda self: six.text_type(self)
 
-        for name, value in JINJA2_CONSTANTS.items():
-            self.globals[name] = value
+    if not hasattr(ErrorDict, "__html__"):
+        ErrorDict.__html__ = lambda self: six.text_type(self)
 
-        self.add_extension(builtins.extensions.CsrfExtension)
-        self.add_extension(builtins.extensions.CacheExtension)
 
-    def get_templatetags_modules_list(self):
-        """
-        Get list of modules that contains templatetags
-        submodule.
-        """
-        # Django 1.7 compatibility imports
-        try:
-            from django.apps import apps
-            all_modules = [x.name for x in apps.get_app_configs()]
-        except ImportError:
-            all_modules = settings.INSTALLED_APPS
+def preload_templatetags_from_apps():
+    """
+    Iterate over all available apps in searching and preloading
+    available template filters or functions for jinja2.
+    """
 
-        mod_list = []
-        for app_path in all_modules:
+    for app_path, mod_path in _iter_templatetags_modules_list():
+        if not os.path.isdir(mod_path):
+            continue
+
+        for filename in filter(lambda x: x.endswith(".py") or x.endswith(".pyc"), os.listdir(mod_path)):
+            # Exclude __init__.py files
+            if filename == "__init__.py" or filename == "__init__.pyc":
+                continue
+
+            file_mod_path = "%s.templatetags.%s" % (app_path, filename.rsplit(".", 1)[0])
             try:
-                mod = import_module(app_path + ".templatetags")
-                if mod is not None:
-                    mod_list.append((app_path, os.path.dirname(mod.__file__)))
+                import_module(file_mod_path)
             except ImportError:
                 pass
 
-        return mod_list
 
-    def preload_templatetags_modules(self):
-        """
-        Given a ready modules list, try import all modules
-        related to templatetags for populate a library.
-        """
+def _initialize_builtins(env):
+    """
+    Inject into environment instances builtin
+    filters, tests, globals, and constants.
+    """
+    for name, value in JINJA2_FILTERS.items():
+        if isinstance(value, six.string_types):
+            env.filters[name] = utils.load_class(value)
+        else:
+            env.filters[name] = value
 
-        for app_path, mod_path in self.get_templatetags_modules_list():
-            if not os.path.isdir(mod_path):
-                continue
+    for name, value in JINJA2_TESTS.items():
+        if isinstance(value, six.string_types):
+            env.tests[name] = utils.load_class(value)
+        else:
+            env.tests[name] = value
 
-            for filename in filter(lambda x: x.endswith(".py") or x.endswith(".pyc"), os.listdir(mod_path)):
-                # Exclude __init__.py files
-                if filename == "__init__.py" or filename == "__init__.pyc":
-                    continue
+    for name, value in JINJA2_GLOBALS.items():
+        if isinstance(value, six.string_types):
+            env.globals[name] = utils.load_class(value)
+        else:
+            env.globals[name] = value
 
-                file_mod_path = "%s.templatetags.%s" % (app_path, filename.rsplit(".", 1)[0])
-                try:
-                    import_module(file_mod_path)
-                except ImportError:
-                    pass
+    for name, value in JINJA2_CONSTANTS.items():
+        env.globals[name] = value
 
-    def initialize_thirdparty_templatetags(self):
-        self.preload_templatetags_modules()
-        library._update_env(self)
+    env.add_extension(builtins.extensions.CsrfExtension)
+    env.add_extension(builtins.extensions.CacheExtension)
 
-initial_params = {
-    "autoescape": JINJA2_AUTOESCAPE,
-    "extensions": list(set(list(JINJA2_EXTENSIONS) + DEFAULT_EXTENSIONS)),
-}
 
-initial_params.update(JINJA2_ENVIRONMENT_OPTIONS)
+def _initialize_thirdparty(env):
+    library._update_env(env)
 
-env = Environment(**initial_params)
 
-# Initialize environment inline
+def _initialize_i18n(env):
+    # install translations
+    if settings.USE_I18N:
+        from django.utils import translation
+        env.install_gettext_translations(translation, newstyle=JINJA2_NEWSTYLE_GETTEXT)
+    else:
+        env.install_null_translations(newstyle=JINJA2_NEWSTYLE_GETTEXT)
+
+
+def _initialize_template_loader(env):
+    loader = getattr(settings, "JINJA2_LOADER", None)
+
+    # Create a default loader using django template dirs
+    # and django app template dirs.
+    if loader is None:
+        from django.template.loaders import app_directories
+        default_loader_dirs = (tuple(settings.TEMPLATE_DIRS) +
+                               app_directories.app_template_dirs)
+        env.loader = jinja2.FileSystemLoader(default_loader_dirs)
+
+    # And in the last case, attach it as is.
+    else:
+        env.loader = loader
+
+
+def _initialize_bytecode_cache(env):
+    if JINJA2_BYTECODE_CACHE_ENABLE:
+        cls = utils.load_class(JINJA2_BYTECODE_CACHE_BACKEND)
+        env.bytecode_cache = cls(JINJA2_BYTECODE_CACHE_NAME)
+
+
+def make_environemnt(defaults=None, clspath=None):
+    """
+    Create a new instance of jinja2 environment.
+    """
+    initial_params = {"autoescape": JINJA2_AUTOESCAPE}
+    initial_params.update(JINJA2_ENVIRONMENT_OPTIONS)
+
+    if "extensions" not in initial_params:
+        initial_params["extensions"] = []
+
+    initial_params["extensions"].extend(DEFAULT_EXTENSIONS)
+    initial_params["extensions"].extend(JINJA2_EXTENSIONS)
+
+    if settings.DEBUG:
+        initial_params["undefined"] = jinja2.DebugUndefined
+    else:
+        initial_params["undefined"] = jinja2.Undefined
+
+    if defaults is not None:
+        initial_params.update(defaults)
+
+    if clspath is None:
+        clspath = "jinja2.Environment"
+
+    cls = utils.load_class(clspath)
+    env = cls(**initial_params)
+    env.template_class = Template
+
+    return env
+
+
+def initialize(env):
+    """
+    Initialize given environment populating it with
+    builtins and with django i18n data.
+    """
+    _initialize_builtins(env)
+    _initialize_thirdparty(env)
+    _initialize_i18n(env)
+    _initialize_template_loader(env)
+    _initialize_bytecode_cache(env)
+
+
+def setup():
+    patch_django_for_autoescape()
+    preload_templatetags_from_apps()
+    initialize(env)
+
+
+# Create a global instance for preserve
+# the previos behavior (django <= 1.7.x)
+env = make_environemnt()
+
+
+# Fallback for prevous django versions.
 if django.VERSION[:2] < (1, 7):
-    env.initialize()
-
-__all__ = ["env", "initialize_environment"]
+    setup()

--- a/django_jinja/builtins/filters.py
+++ b/django_jinja/builtins/filters.py
@@ -31,7 +31,7 @@ def static(path):
 from django.template.defaultfilters import addslashes
 from django.template.defaultfilters import capfirst
 from django.utils.html import escapejs as escapejs_filter
-from django.utils.html import fix_ampersands as fix_ampersands_filter
+# from django.utils.html import fix_ampersands as fix_ampersands_filter
 from django.template.defaultfilters import floatformat
 from django.template.defaultfilters import iriencode
 from django.template.defaultfilters import linenumbers

--- a/django_jinja/loaders.py
+++ b/django_jinja/loaders.py
@@ -4,6 +4,7 @@ way for get it working.
 """
 
 import re
+import jinja2
 
 from django.conf import settings
 from django.template import TemplateDoesNotExist
@@ -11,37 +12,33 @@ from django.template.loaders import app_directories
 from django.template.loaders import filesystem
 from django_jinja.base import env
 
-import jinja2
-
+from . import base
 
 if hasattr(settings, "DEFAULT_JINJA2_TEMPLATE_INTERCEPT_RE"):
-    RE_INTERCEPT_ON = True
-    DEFAULT_JINJA2_TEMPLATE_INTERCEPT_RE = \
-        settings.DEFAULT_JINJA2_TEMPLATE_INTERCEPT_RE
-    RE_INTERCEPT = re.compile(settings.DEFAULT_JINJA2_TEMPLATE_INTERCEPT_RE)
+    INTERCEPT_RE = getattr(settings, "DEFAULT_JINJA2_TEMPLATE_INTERCEPT_RE")
+    REGEX = re.compile(INTERCEPT_RE)
+    EXTENSION = None
 else:
-    RE_INTERCEPT_ON = False
-    DEFAULT_JINJA2_TEMPLATE_EXTENSION = getattr(settings,
-        'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
+    REGEX = None
+    EXTENSION = getattr(settings, 'DEFAULT_JINJA2_TEMPLATE_EXTENSION', '.jinja')
 
 
 class LoaderMixin(object):
     is_usable = True
 
+    def match_template(self, template_name):
+        return base.match_template(template_name, regex=REGEX, extension=EXTENSION)
+
     def load_template(self, template_name, template_dirs=None):
-        # If regex intercept is off (default), try template intercept by extension.
-        if (not RE_INTERCEPT_ON and not template_name.endswith(DEFAULT_JINJA2_TEMPLATE_EXTENSION)):
+        if self.match_template(template_name):
+            try:
+                template = env.get_template(template_name)
+                return template, template.filename
+            except jinja2.TemplateNotFound:
+                raise TemplateDoesNotExist(template_name)
+        else:
             return super(LoaderMixin, self).load_template(template_name, template_dirs)
 
-        # If regex intercept is on, try regex match over template name.
-        elif RE_INTERCEPT_ON and not RE_INTERCEPT.match(template_name):
-            return super(LoaderMixin, self).load_template(template_name, template_dirs)
-
-        try:
-            template = env.get_template(template_name)
-            return template, template.filename
-        except jinja2.TemplateNotFound:
-            raise TemplateDoesNotExist(template_name)
 
 
 class FileSystemLoader(LoaderMixin, filesystem.Loader):

--- a/django_jinja/loaders.py
+++ b/django_jinja/loaders.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+"""
+Api for django <= 1.7.x that uses loader extending
+way for get it working.
+"""
 
 import re
 
@@ -26,14 +29,11 @@ class LoaderMixin(object):
     is_usable = True
 
     def load_template(self, template_name, template_dirs=None):
-        # If regex intercept is off (default), try
-        # template intercept by extension.
-        if (not RE_INTERCEPT_ON and
-                not template_name.endswith(DEFAULT_JINJA2_TEMPLATE_EXTENSION)):
+        # If regex intercept is off (default), try template intercept by extension.
+        if (not RE_INTERCEPT_ON and not template_name.endswith(DEFAULT_JINJA2_TEMPLATE_EXTENSION)):
             return super(LoaderMixin, self).load_template(template_name, template_dirs)
 
-        # If regex intercept is on, try regex match over
-        # template name.
+        # If regex intercept is on, try regex match over template name.
         elif RE_INTERCEPT_ON and not RE_INTERCEPT.match(template_name):
             return super(LoaderMixin, self).load_template(template_name, template_dirs)
 

--- a/django_jinja/views.py
+++ b/django_jinja/views.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import django
+
 from django.conf import settings
 from django.views.generic import View
 from django.template import loader, RequestContext
@@ -16,8 +18,12 @@ class GenericView(View):
 
     def get(self, request, *args, **kwargs):
         context = self.get_context_data()
-        output = loader.render_to_string(self.tmpl_name, context,
-                                         context_instance=RequestContext(request))
+        if django.VERSION[:2] < (1, 8):
+            output = loader.render_to_string(self.tmpl_name, context,
+                                             context_instance=RequestContext(request))
+        else:
+            output = loader.render_to_string(self.tmpl_name, context, request=request)
+
         return self.response_cls(output, content_type=self.content_type)
 
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1,18 +1,15 @@
-django-jinja documentation
-==========================
+= django-jinja - Jinja2 Template Engine for Django
 Andrey Antukh, <niwi@niwi.be>
-1.0.5
+1.1.0
 :toc: left
 :numbered:
 :source-highlighter: pygments
 :pygments-style: friendly
 
 
-Introduction
-------------
+== Introduction
 
 django-jinja is a xref:license[BSD Licensed], simple and nonobstructive jinja2 integration with Django.
-
 
 Jinja2 provides certain advantages over the native system of Django, for example, explicit calls to
 callable from templates, has better performance and has a plugin system, etc ...
@@ -25,16 +22,7 @@ There are other projects that attempt do same thing: Djinja, Coffin, etc... Why 
   maintainable and easily understandable how the library works.
 
 
-Requirements
-------------
-
-- Python 2.7, 3.3 or 3.4
-- Django 1.4, 1.5, 1.6 and 1.7
-- jinja2 >= 2.7.0
-
-
-Features
---------
+=== Features
 
 - Auto-load templatetags compatible with Jinja2 on same way as Django.
 - Django templates can coexist with Jinja2 templates without any problems.
@@ -43,14 +31,38 @@ Features
 - I18n subsystem adapted for Jinja2 (makemessages now collects messages from Jinja templates)
 - Compatible with python2 and python3 using same codebase.
 - jinja2 bytecode cache adapted for use django cache subsystem.
+- Django 1.8 support out of the box.
 
 
+=== Django 1.8 support
 
-User guide
-----------
+Django 1.8 introduces multiple template engines support and comes with Jinja2 backend.
 
-Installation
-~~~~~~~~~~~~
+But it has some drawbacks:
+
+- not autoloads template tags.
+- by default search templates on _jinja2_ directory instead of _templates_ (jinja2 are also templates,
+  I don't understand why put them in different directory?)
+- not setups i18n support.
+- not has support for django context processors.
+
+In summary, for make it working like _django_jinja_ is already working for years, it requires a lot
+of boilerplate.
+
+*django-jinja since version 1.1 also comes with django 1.8 compatible backend*, but supporting all
+the things.
+
+
+== Requirements
+
+- Python 2.7, 3.3 or 3.4
+- Django 1.5, 1.6, 1.7 and 1.8
+- jinja2 >= 2.7.0
+
+
+== User guide
+
+=== Installation
 
 The simplest way to install **django-jinja** is using **pip**:
 
@@ -59,9 +71,14 @@ The simplest way to install **django-jinja** is using **pip**:
 pip install django-jinja
 ----
 
+Add add it to django installed apps list:
 
-Configure
-~~~~~~~~~
+[source, python]
+----
+INSTALLED_APPS += ('django_jinja',)
+----
+
+=== Configure for django +++<=+++ 1.7
 
 The first step for configure _django-jinja_ is replace default
 django template loaders:
@@ -74,15 +91,8 @@ TEMPLATE_LOADERS = (
 )
 ----
 
-Add add it to django installed apps list:
-
-[source, python]
-----
-INSTALLED_APPS += ('django_jinja',)
-----
-
-django-jinja template loaders inherit's from a django template loaders and works like middleware, intercepts
-by predefined condition templates for render with jinja2 engine.
+django-jinja template loaders inherit's from a django template loaders and works like middleware, 
+intercepts by predefined condition templates for render with jinja2 engine.
 
 The simplest condition is using file extensions:
 
@@ -91,9 +101,9 @@ The simplest condition is using file extensions:
 DEFAULT_JINJA2_TEMPLATE_EXTENSION = '.jinja'
 ----
 
-With this settings, django-jinja intercepts all templates with `.jinja` extension and render them with jinja2
-engine and templates that not matches the `.jinja` extension are forwarded to django templates engine.
-
+With this settings, django-jinja intercepts all templates with `.jinja` extension and render them with 
+jinja2 engine and templates that not matches the `.jinja` extension are forwarded to django templates 
+engine.
 
 Additionaly, *django-jinja* exposes, more advanced matcher, using regular exceptions:
 
@@ -109,8 +119,7 @@ DEFAULT_JINJA2_TEMPLATE_INTERCEPT_RE = r"^(?!admin/).*"
 ----
 
 
-Additional settings
-~~~~~~~~~~~~~~~~~~~
+==== Additional settings
 
 If you need more low level customizations for jinja2 engine, *django-jinja* exposes
 `JINJA2_ENVIRONMENT_OPTIONS` settings for it:
@@ -142,15 +151,11 @@ JINJA2_AUTOESCAPE = True
 # Mute reverse url exceptions (default: False)
 JINJA2_MUTE_URLRESOLVE_EXCEPTIONS = True
 
-# Keep original small subset of jinja filters 
+# Keep original small subset of jinja filters
 # instead of use the django's versions of them.
 # Default: True
 JINJA2_FILTERS_REPLACE_FROM_DJANGO = False
 ----
-
-
-Bytecode Cache
-~~~~~~~~~~~~~~
 
 *django-jinja* supports the Jinja2's template bytecode caching system. Including an implementation
 for makes use of Django's built-in cache framework.
@@ -170,8 +175,74 @@ JINJA2_BYTECODE_CACHE_BACKEND = "path.to.you.cache.class"
 link:http://jinja.pocoo.org/docs/api/#bytecode-cache[More documentation about bytecode cache]
 
 
-Differences
-~~~~~~~~~~~
+=== Configure for django +++>=+++ 1.8
+
+Django 1.8 introduces multiple template engine and new way to configure them.
+
+This is a quick example of how to configure _django-jinja_ with django 1.8 configuration
+formata:
+
+[source, python]
+----
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True
+    },
+    {
+        "BACKEND": "django_jinja.backend.Jinja2",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "match_extension", ".jinja",
+        }
+    },
+]
+----
+
+_django-jinja_ backend, unlike django's one, uses the "templates" directory and works like a middleware.
+It intercepts by extension or by regular expression.
+
+
+Full list of options, almost all them not mandatory:
+
+[source, python]
+----
+TEMPLATES = [
+    {
+        "BACKEND": "django_jinja.backend.Jinja2",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "match_extension": ".jinja",
+            "match_regex": r"^(?!admin/).*", # this is exclusive with match_extension
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+            ],
+            "extensions": [
+                "jinja2.ext.do",
+                "jinja2.ext.loopcontrols",
+                "jinja2.ext.with_",
+                "jinja2.ext.i18n",
+                "jinja2.ext.autoescape",
+            ],
+            "newstyle_gettext": True,
+            "environment": "jinja2.Environment",
+            "auto_reload": settings.DEBUG
+        }
+    }
+]
+----
+
+All other options are passed directly to environment constructor.
+
+
+=== Differences
 
 .Reverse urls in templates
 [source, html+jinja]
@@ -233,6 +304,7 @@ handler403 = views.PermissionDenied.as_view()
 handler404 = views.PageNotFound.as_view()
 handler500 = views.ServerError.as_view()
 ----
+
 
 Known Issues
 ------------
@@ -317,7 +389,7 @@ INSTALLED_APPS += ('django_jinja.contrib._subdomains',)
 humanize
 ~~~~~~~~
 
-Django comes with humanize library that exposes some useful template filters. 
+Django comes with humanize library that exposes some useful template filters.
 
 .Activate plugin (settings.py)
 [source, python]
@@ -334,7 +406,7 @@ License
 
 [source,text]
 ----
-Copyright (c) 2011-2014 Andre Antukh <niwi@niwi.be>
+Copyright (c) 2011-2015 Andre Antukh <niwi@niwi.be>
 
 All rights reserved.
 

--- a/runtests.py
+++ b/runtests.py
@@ -71,8 +71,21 @@ test_settings = {
     "JINJA2_AUTOESCAPE": True,
     "JINJA2_MUTE_URLRESOLVE_EXCEPTIONS": True,
     "TEMPLATES": [
-        {"BACKEND": "django_jinja.backend.Jinja2", "NAME": "jinja2", "APP_DIRS": True}
-    ],
+        {"BACKEND": "django_jinja.backend.Jinja2",
+         "NAME": "jinja2",
+         "APP_DIRS": True,
+         "OPTIONS": {
+             "context_processors": [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+             ]
+         }}
+     ],
 }
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -70,6 +70,9 @@ test_settings = {
     "JINJA2_CONSTANTS": {"foo": "bar"},
     "JINJA2_AUTOESCAPE": True,
     "JINJA2_MUTE_URLRESOLVE_EXCEPTIONS": True,
+    "TEMPLATES": [
+        {"BACKEND": "django_jinja.backend.Jinja2", "NAME": "jinja2", "APP_DIRS": True}
+    ],
 }
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -76,13 +76,13 @@ test_settings = {
          "APP_DIRS": True,
          "OPTIONS": {
              "context_processors": [
-                'django.contrib.auth.context_processors.auth',
-                'django.template.context_processors.debug',
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.media',
-                'django.template.context_processors.static',
-                'django.template.context_processors.tz',
-                'django.contrib.messages.context_processors.messages',
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
              ]
          }}
      ],

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -16,9 +16,9 @@ from django.conf import settings
 from django.shortcuts import render
 
 from django_jinja.base import env, dict_from_context, Template
-from django.template import engines
 
 if django.VERSION[:2] >= (1, 8):
+    from django.template import engines
     env = engines["jinja2"]
 
 from .forms import TestForm

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -4,6 +4,7 @@ from __future__ import print_function, unicode_literals
 
 import datetime
 import sys
+import django
 
 from django.http import HttpResponse
 from django.test import signals, TestCase
@@ -15,6 +16,10 @@ from django.conf import settings
 from django.shortcuts import render
 
 from django_jinja.base import env, dict_from_context, Template
+from django.template import engines
+
+if django.VERSION[:2] >= (1, 8):
+    env = engines["jinja2"]
 
 from .forms import TestForm
 

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -167,10 +167,15 @@ class TemplateFunctionsTest(TestCase):
         else:
             request.META["CSRF_COOKIE"] = '1234123123'
 
-        context = dict_from_context(RequestContext(request))
+        if django.VERSION[:2] >= (1, 8):
+            template = env.from_string(template_content)
+            result = template.render({}, request)
 
-        template = env.from_string(template_content)
-        result = template.render(context)
+        else:
+            context = dict_from_context(RequestContext(request))
+            template = env.from_string(template_content)
+            result = template.render(context)
+
         self.assertEqual(result, "<input type='hidden' name='csrfmiddlewaretoken' value='1234123123' />")
 
     def test_cache_01(self):
@@ -286,5 +291,4 @@ class TemplateDebugSignalsTest(TestCase):
         with self.settings(TEMPLATE_DEBUG=True):
             request = RequestFactory().get('/')
             response = view(request, template_name=template_name)
-            self.assertTemplateUsed(response, template_name)
             self.assertEqual(response.content, b"success")


### PR DESCRIPTION
Missing:

- [x] Adapt old code making it more friendly with django 1.8
- [x] Add initial version of jinja2 backend compliant with django 1.8
- [x] Adapt builtin views for work properly without deprecation warnings.
- [x] Add context processors support for backward compatibility and because it is util.
- [ ] Add documentation about changes and how to use django_jinja with django 1.8
- [x] Clean code making it more simple and beautiful. 
- [ ] Make exhaustive test for not breaking more that expected things.