### PR TITLE
Fix AttributeError with Python 3 and empty folders

### DIFF
--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -163,7 +163,9 @@ def _iter_templatetags_modules_list():
     for app_path in all_modules:
         try:
             mod = import_module(app_path + ".templatetags")
-            if mod is not None:
+            # Empty folders can lead to unexpected behavior with Python 3.
+            # We make sure to have the `__file__` attribute.
+            if hasattr(mod, '__file__'):
                 yield (app_path, os.path.dirname(mod.__file__))
         except ImportError:
             pass


### PR DESCRIPTION
With Python 3 the imported `mod` might be an empty folder, which does not have a `__file__` attribute.
We make sure to have this attribute before yielding a result.

It follows the discussion in #75.