### PR TITLE
update docs with help on using contrib modules

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -351,7 +351,8 @@ Builtin contrib modules
 -----------------------
 
 *django-jinja* comes with some additional contrib modules that adapts limited set of external
-django apps for use it easy from jinja templates.
+django apps for use it easy from jinja templates. Please note that in order to use any of these
+contrib modules, you'll need to install the relevant dependent package yourself first.
 
 
 [NOTE]


### PR DESCRIPTION
This may seem obvious to some but took me awhile to figure out that the easy-thumbnails wasn't self-contained and that I had to pip install easy-thumbnails for it to work. I imagine others will assume the modules themselves are bundled in the contrib.