### PR TITLE
Allow optional whitespace in tail of trans tag

### DIFF
--- a/django_jinja/management/commands/makemessages.py
+++ b/django_jinja/management/commands/makemessages.py
@@ -48,7 +48,7 @@ class Command(makemessages.Command):
         trans_real.endblock_re = re.compile(
             trans_real.endblock_re.pattern + '|' + r"""^-?\s*endtrans\s*-?$""")
         trans_real.block_re = re.compile(
-            trans_real.block_re.pattern + '|' + r"""^-?\s*trans(?:\s+(?!'|")(?=.*?=.*?)|-?$)""")
+            trans_real.block_re.pattern + '|' + r"""^-?\s*trans(?:\s+(?!'|")(?=.*?=.*?)|\s*-?$)""")
         trans_real.plural_re = re.compile(
             trans_real.plural_re.pattern + '|' + r"""^-?\s*pluralize(?:\s+.+|-?$)""")
 

--- a/django_jinja/management/commands/makemessages.py
+++ b/django_jinja/management/commands/makemessages.py
@@ -27,7 +27,7 @@ http://stackoverflow.com/questions/2090717/getting-translation-strings-for-jinja
 import re
 from django.core.management.commands import makemessages
 from django.utils.translation import trans_real
-from django.template import BLOCK_TAG_START, BLOCK_TAG_END
+from django.template.base import BLOCK_TAG_START, BLOCK_TAG_END
 
 strip_whitespace_right = re.compile(r"(%s-?\s*(trans|pluralize).*?-%s)\s+" % (BLOCK_TAG_START, BLOCK_TAG_END), re.U)
 strip_whitespace_left = re.compile(r"\s+(%s-\s*(endtrans|pluralize).*?-?%s)" % (BLOCK_TAG_START, BLOCK_TAG_END), re.U)


### PR DESCRIPTION
Fixes a problem where whitespace towards the end of a whitespace stripping `trans` block would prevent makemessages from collecting strings.

The following format is now supported:
    {% trans -%}
        some text
    {-% endtrans %}