### PR TITLE
Make match_extension and match_regex work together.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ python:
   - "2.7"
 
 env:
+  - DJANGO="django==1.8.0"
   - DJANGO="django==1.7.4"
   - DJANGO="django==1.6.10"
   - DJANGO="django==1.5.12"
   - DJANGO="django==1.4.19"
-  - DJANGO="https://www.djangoproject.com/download/1.8c1/tarball/"
 
 matrix:
   exclude:

--- a/django_jinja/base.py
+++ b/django_jinja/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import re
 from importlib import import_module
 
 import django
@@ -249,10 +250,14 @@ def _initialize_bytecode_cache(env):
 
 
 def match_template(template_name, regex=None, extension=None):
-    if extension is not None:
-        return template_name.endswith(extension)
+    if extension:
+        matches_extension = template_name.endswith(extension)
+        if regex:
+            return matches_extension and re.match(regex, template_name)
+        else:
+            return template_name.endswith(extension)
     elif regex:
-        return regex.match(template_name)
+        return re.match(regex, template_name)
     else:
         return False
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -258,7 +258,7 @@ Additionaly, *django-jinja* exposes, more advanced matcher, using regular except
 [source, python]
 ----
 "OPTIONS": {
-    "match_regex": r"^(?!admin/).*", # this is exclusive with match_extension
+    "match_regex": r"^(?!admin/).*", # this is additive to match_extension
 }
 ----
 
@@ -365,8 +365,10 @@ TEMPLATES = [
         "BACKEND": "django_jinja.backend.Jinja2",
         "APP_DIRS": True,
         "OPTIONS": {
-            "match_extension": ".jinja",
-            "match_regex": "*\.jinja$", # This is exclusive with "match_extension"
+            # Match the template names ending in .html but not the ones in the admin folder.
+            "match_extension": ".html",
+            "match_regex": r"^(?!admin/).*",
+
             "newstyle_gettext": True,
             "tests": {
                 "mytest": "path.to.my.test",

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -15,7 +15,7 @@ from django.core.urlresolvers import NoReverseMatch
 from django.conf import settings
 from django.shortcuts import render
 
-from django_jinja.base import env, dict_from_context, Template
+from django_jinja.base import env, dict_from_context, Template, match_template
 
 if django.VERSION[:2] >= (1, 8):
     from django.template import engines
@@ -294,3 +294,17 @@ class TemplateDebugSignalsTest(TestCase):
             request = RequestFactory().get('/')
             response = view(request, template_name=template_name)
             self.assertEqual(response.content, b"success")
+
+
+class BaseTests(TestCase):
+    def test_match_template(self):
+        self.assertFalse(
+            match_template('admin/foo.html', regex=None, extension=None))
+        self.assertFalse(
+            match_template('admin/foo.html', regex=None, extension='.jinja'))
+        self.assertTrue(
+            match_template('admin/foo.html', regex=None, extension='.html'))
+        self.assertTrue(
+            match_template('admin/foo.html', regex=r'.*\.html', extension=None))
+        self.assertFalse(
+            match_template('admin/foo.html', regex=r"^(?!admin/.*)", extension=None))


### PR DESCRIPTION
Configuration defaults in extension being '.jinja' and match_regex being
None.

If you want to match all files ending with .html you will set
`match_extension` to `.html`. As expected this will also match files
from third party django apps, like the django.contrib.admin app.

We need a way to match all html files but exclude some based on the
location which matches the package name. So match_extension and
match_regex should work together.

Updated the documentation to provide a working example with jinja
applied on all .html files but the ones from the admin app.

Took the chance to fix `regex.match` which failed anyway because `regex`
is a string.